### PR TITLE
Add command suggestions

### DIFF
--- a/common/src/main/java/eu/mcdb/universal/command/UniversalCommand.java
+++ b/common/src/main/java/eu/mcdb/universal/command/UniversalCommand.java
@@ -19,6 +19,8 @@ package eu.mcdb.universal.command;
 
 import eu.mcdb.universal.Server;
 
+import java.util.List;
+
 public abstract class UniversalCommand {
 
     private final String name;
@@ -58,6 +60,15 @@ public abstract class UniversalCommand {
      * @return true if the command execution ended successfully
      */
     public abstract boolean onCommand(UniversalCommandSender sender, String[] args);
+
+    /**
+     * Get a list of command suggestions
+     *
+     * @param sender the sender attempting to get suggestions
+     * @param args the entered arguments
+     * @return a list of command suggestions
+     */
+    public abstract List<String> getSuggestions(UniversalCommandSender sender, String[] args);
 
     /**
      * Get the command name.

--- a/common/src/main/java/eu/mcdb/universal/command/api/CommandParameter.java
+++ b/common/src/main/java/eu/mcdb/universal/command/api/CommandParameter.java
@@ -32,6 +32,8 @@ public class CommandParameter {
     private String displayName;
     @Getter
     private final boolean optional;
+    @Getter
+    private ParameterSuggestionProvider suggestionProvider;
 
     /**
      * Create a command parameter with the given name

--- a/common/src/main/java/eu/mcdb/universal/command/api/ParameterSuggestionProvider.java
+++ b/common/src/main/java/eu/mcdb/universal/command/api/ParameterSuggestionProvider.java
@@ -1,0 +1,13 @@
+package eu.mcdb.universal.command.api;
+
+import java.util.List;
+
+/**
+ * Provides suggestions for a {@link CommandParameter}
+ */
+@FunctionalInterface
+public interface ParameterSuggestionProvider {
+
+    List<String> suggest(String[] args);
+
+}

--- a/minecraft/src/main/java/org/spicord/bukkit/server/BukkitCommandExecutor.java
+++ b/minecraft/src/main/java/org/spicord/bukkit/server/BukkitCommandExecutor.java
@@ -1,15 +1,14 @@
 package org.spicord.bukkit.server;
 
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
+import org.bukkit.command.*;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import eu.mcdb.universal.command.UniversalCommand;
-import eu.mcdb.universal.command.UniversalCommandSender;
 
-public final class BukkitCommandExecutor implements CommandExecutor {
+import java.util.List;
+
+public final class BukkitCommandExecutor implements CommandExecutor, TabCompleter {
 
     private final UniversalCommand command;
 
@@ -19,33 +18,29 @@ public final class BukkitCommandExecutor implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command arg1, String arg2, String[] args) {
-        UniversalCommandSender commandSender;
+        return command.onCommand(
+            sender instanceof Player
+                ? new BukkitPlayer((Player) sender)
+                : new BukkitCommandSender(sender),
+            args
+        );
+    }
 
-        if (sender instanceof Player) {
-            commandSender = new BukkitPlayer((Player) sender);
-        } else {
-            commandSender = new UniversalCommandSender() {
-
-                @Override
-                public boolean hasPermission(String permission) {
-                    return isEmpty(permission) || sender.hasPermission(permission);
-                }
-
-                @Override
-                public void sendMessage(String message) {
-                    sender.sendMessage(message);
-                }
-
-                private boolean isEmpty(String string) {
-                    return string == null || string.isEmpty();
-                }
-            };
-        }
-
-        return command.onCommand(commandSender, args);
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command cmd, String label, String[] args) {
+        return command.getSuggestions(
+            sender instanceof Player
+                ? new BukkitPlayer((Player) sender)
+                : new BukkitCommandSender(sender),
+            args
+        );
     }
 
     public static void register(JavaPlugin plugin, UniversalCommand command) {
-        plugin.getCommand(command.getName()).setExecutor(new BukkitCommandExecutor(command));
+        PluginCommand pluginCommand = plugin.getCommand(command.getName());
+        BukkitCommandExecutor executor = new BukkitCommandExecutor(command);
+
+        pluginCommand.setExecutor(executor);
+        pluginCommand.setTabCompleter(executor);
     }
 }

--- a/minecraft/src/main/java/org/spicord/bukkit/server/BukkitCommandSender.java
+++ b/minecraft/src/main/java/org/spicord/bukkit/server/BukkitCommandSender.java
@@ -1,0 +1,28 @@
+package org.spicord.bukkit.server;
+
+import eu.mcdb.universal.command.UniversalCommandSender;
+import org.bukkit.command.CommandSender;
+
+public class BukkitCommandSender extends UniversalCommandSender {
+
+    private final CommandSender sender;
+
+    public BukkitCommandSender(CommandSender sender) {
+        this.sender = sender;
+    }
+
+    @Override
+    public boolean hasPermission(String permission) {
+        return isEmpty(permission) || sender.hasPermission(permission);
+    }
+
+    @Override
+    public void sendMessage(String message) {
+        sender.sendMessage(message);
+    }
+
+    private boolean isEmpty(String string) {
+        return string == null || string.isEmpty();
+    }
+
+}

--- a/minecraft/src/main/java/org/spicord/bungee/server/BungeeCommandExecutor.java
+++ b/minecraft/src/main/java/org/spicord/bungee/server/BungeeCommandExecutor.java
@@ -1,14 +1,13 @@
 package org.spicord.bungee.server;
 
 import eu.mcdb.universal.command.UniversalCommand;
-import eu.mcdb.universal.command.UniversalCommandSender;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.api.plugin.Plugin;
+import net.md_5.bungee.api.plugin.TabExecutor;
 
-public final class BungeeCommandExecutor extends Command {
+public final class BungeeCommandExecutor extends Command implements TabExecutor {
 
     private final UniversalCommand command;
 
@@ -19,31 +18,24 @@ public final class BungeeCommandExecutor extends Command {
 
     @Override
     public void execute(CommandSender sender, String[] args) {
-        UniversalCommandSender commandSender;
-
-        if (sender instanceof ProxiedPlayer) {
-            commandSender = new BungeePlayer((ProxiedPlayer) sender);
-        } else {
-            commandSender = new UniversalCommandSender() {
-
-                @Override
-                public boolean hasPermission(String permission) {
-                    return isEmpty(permission) || sender.hasPermission(permission);
-                }
-
-                @Override
-                public void sendMessage(String message) {
-                    sender.sendMessage(new TextComponent(message));
-                }
-
-                private boolean isEmpty(String string) {
-                    return string == null || string.isEmpty();
-                }
-            };
-        }
-
-        command.onCommand(commandSender, args);
+        command.onCommand(
+            sender instanceof ProxiedPlayer
+                ? new BungeePlayer(((ProxiedPlayer) sender))
+                : new BungeeCommandSender(sender),
+            args
+        );
     }
+
+    @Override
+    public Iterable<String> onTabComplete(CommandSender sender, String[] args) {
+        return command.getSuggestions(
+            sender instanceof ProxiedPlayer
+                ? new BungeePlayer(((ProxiedPlayer) sender))
+                : new BungeeCommandSender(sender),
+            args
+        );
+    }
+
 
     public static void register(Plugin plugin, UniversalCommand command) {
         plugin.getProxy().getPluginManager().registerCommand(plugin, new BungeeCommandExecutor(command));

--- a/minecraft/src/main/java/org/spicord/bungee/server/BungeeCommandSender.java
+++ b/minecraft/src/main/java/org/spicord/bungee/server/BungeeCommandSender.java
@@ -1,0 +1,29 @@
+package org.spicord.bungee.server;
+
+import eu.mcdb.universal.command.UniversalCommandSender;
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.chat.TextComponent;
+
+public class BungeeCommandSender extends UniversalCommandSender {
+
+    private final CommandSender sender;
+
+    public BungeeCommandSender(CommandSender sender) {
+        this.sender = sender;
+    }
+
+    @Override
+    public boolean hasPermission(String permission) {
+        return isEmpty(permission) || sender.hasPermission(permission);
+    }
+
+    @Override
+    public void sendMessage(String message) {
+        sender.sendMessage(new TextComponent(message));
+    }
+
+    private boolean isEmpty(String string) {
+        return string == null || string.isEmpty();
+    }
+
+}

--- a/minecraft/src/main/java/org/spicord/sponge/server/SpongeCommandExecutor.java
+++ b/minecraft/src/main/java/org/spicord/sponge/server/SpongeCommandExecutor.java
@@ -1,98 +1,78 @@
 package org.spicord.sponge.server;
 
-import java.util.Optional;
-
+import eu.mcdb.universal.command.UniversalCommand;
+import net.kyori.adventure.text.Component;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.Command;
-import org.spongepowered.api.command.Command.Parameterized;
-import org.spongepowered.api.command.CommandExecutor;
+import org.spongepowered.api.command.CommandCause;
+import org.spongepowered.api.command.CommandCompletion;
 import org.spongepowered.api.command.CommandResult;
-import org.spongepowered.api.command.exception.CommandException;
-import org.spongepowered.api.command.parameter.CommandContext;
-import org.spongepowered.api.command.parameter.Parameter;
+import org.spongepowered.api.command.parameter.ArgumentReader;
 import org.spongepowered.api.command.registrar.CommandRegistrar;
 import org.spongepowered.api.entity.living.player.server.ServerPlayer;
 import org.spongepowered.plugin.PluginContainer;
 
-import eu.mcdb.universal.command.UniversalCommand;
-import eu.mcdb.universal.command.UniversalCommandSender;
-import net.kyori.adventure.identity.Identity;
-import net.kyori.adventure.text.Component;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
-public class SpongeCommandExecutor implements CommandExecutor {
+public class SpongeCommandExecutor implements Command.Raw {
 
     private final UniversalCommand command;
 
-    private Command.Parameterized spongeCommand;
-
-    private Parameter.Value<String> argsParameter;
-
     public SpongeCommandExecutor(final UniversalCommand command) {
         this.command = command;
-
-        final Command.Builder builder = Command.builder()
-                .addParameter(
-                        argsParameter = Parameter.remainingJoinedStrings()
-                            .key("args")
-                            .consumeAllRemaining()
-                            .build()
-                )
-                .executor(this);
-
-        if (command.getPermission() != null) {
-            builder.permission(command.getPermission());
-        }
-
-        spongeCommand = builder.build();
     }
 
     @Override
-    public CommandResult execute(CommandContext context) throws CommandException {
-        final UniversalCommandSender commandSender;
-
-        if (context.subject() instanceof ServerPlayer) {
-            commandSender = new SpongePlayer((ServerPlayer) context.subject());
-        } else {
-            commandSender = new UniversalCommandSender() {
-
-                @Override
-                public boolean hasPermission(String permission) {
-                    return isEmpty(permission) || context.hasPermission(permission);
-                }
-
-                @Override
-                public void sendMessage(String message) {
-                    context.sendMessage(Identity.nil(), Component.text(message));
-                }
-
-                private boolean isEmpty(String string) {
-                    return string == null || string.isEmpty();
-                }
-            };
-        }
-
-        final String[] args = context.requireOne(argsParameter).split(" ");
-
-        command.onCommand(commandSender, args);
-
+    public CommandResult process(CommandCause cause, ArgumentReader.Mutable arguments) {
+        command.onCommand(
+            cause.subject() instanceof ServerPlayer
+                ? new SpongePlayer((ServerPlayer) cause.subject())
+                : new SpongeCommandSender(cause),
+            arguments.input().split(" ")
+        );
         return CommandResult.success();
     }
 
-    public Command.Parameterized getSpongeCommand() {
-        return spongeCommand;
+    @Override
+    public List<CommandCompletion> complete(CommandCause cause, ArgumentReader.Mutable arguments) {
+        return command.getSuggestions(
+            cause.subject() instanceof ServerPlayer
+                ? new SpongePlayer((ServerPlayer) cause.subject())
+                : new SpongeCommandSender(cause),
+            arguments.input().split(" ", -1) // Include trailing spaces
+        ).stream().map(CommandCompletion::of).collect(Collectors.toList());
     }
+
+    @Override
+    public boolean canExecute(CommandCause cause) {
+        String permission = command.getPermission();
+        return
+            permission == null
+            || permission.isEmpty()
+            || cause.hasPermission(permission);
+    }
+
+    @Override
+    public Optional<Component> shortDescription(CommandCause cause) { return Optional.empty(); }
+
+    @Override
+    public Optional<Component> extendedDescription(CommandCause cause) { return Optional.empty(); }
+
+    @Override
+    public Component usage(CommandCause cause) { return null; }
 
     public static void register(Object pluginInstance, UniversalCommand command) {
         final Optional<PluginContainer> container = Sponge.game().pluginManager().fromInstance(pluginInstance);
 
         if (container.isPresent()) {
-            final Optional<CommandRegistrar<Parameterized>> registrar = Sponge.server().commandManager().registrar(Command.Parameterized.class);
+            final Optional<CommandRegistrar<Raw>> registrar = Sponge.server().commandManager().registrar(Command.Raw.class);
 
             if (registrar.isPresent()) {
-                final SpongeCommandExecutor executor = new SpongeCommandExecutor(command);
-
-                registrar.get().register(container.get(), executor.getSpongeCommand(), command.getName(), command.getAliases());
+                registrar.get().register(container.get(), new SpongeCommandExecutor(command), command.getName(), command.getAliases());
             }
         }
     }
+
 }

--- a/minecraft/src/main/java/org/spicord/sponge/server/SpongeCommandExecutor.java
+++ b/minecraft/src/main/java/org/spicord/sponge/server/SpongeCommandExecutor.java
@@ -30,7 +30,9 @@ public class SpongeCommandExecutor implements Command.Raw {
             cause.subject() instanceof ServerPlayer
                 ? new SpongePlayer((ServerPlayer) cause.subject())
                 : new SpongeCommandSender(cause),
-            arguments.input().split(" ")
+            arguments.input().isEmpty()
+                ? new String[0]
+                : arguments.input().split(" ")
         );
         return CommandResult.success();
     }

--- a/minecraft/src/main/java/org/spicord/sponge/server/SpongeCommandSender.java
+++ b/minecraft/src/main/java/org/spicord/sponge/server/SpongeCommandSender.java
@@ -1,0 +1,30 @@
+package org.spicord.sponge.server;
+
+import eu.mcdb.universal.command.UniversalCommandSender;
+import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.text.Component;
+import org.spongepowered.api.command.CommandCause;
+
+public class SpongeCommandSender extends UniversalCommandSender {
+
+    private final CommandCause cause;
+
+    public SpongeCommandSender(CommandCause cause) {
+        this.cause = cause;
+    }
+
+    @Override
+    public boolean hasPermission(String permission) {
+        return isEmpty(permission) || cause.hasPermission(permission);
+    }
+
+    @Override
+    public void sendMessage(String message) {
+        cause.sendMessage(Identity.nil(), Component.text(message));
+    }
+
+    private boolean isEmpty(String string) {
+        return string == null || string.isEmpty();
+    }
+
+}

--- a/minecraft/src/main/java/org/spicord/velocity/server/VelocityCommandExecutor.java
+++ b/minecraft/src/main/java/org/spicord/velocity/server/VelocityCommandExecutor.java
@@ -7,8 +7,8 @@ import com.velocitypowered.api.command.SimpleCommand;
 import com.velocitypowered.api.proxy.Player;
 
 import eu.mcdb.universal.command.UniversalCommand;
-import eu.mcdb.universal.command.UniversalCommandSender;
-import net.kyori.adventure.text.Component;
+
+import java.util.List;
 
 public final class VelocityCommandExecutor implements SimpleCommand {
 
@@ -21,32 +21,23 @@ public final class VelocityCommandExecutor implements SimpleCommand {
     @Override
     public void execute(Invocation invocation) {
         final CommandSource source = invocation.source();
-        final String[] args = invocation.arguments();
+        command.onCommand(
+            source instanceof Player
+                ? new VelocityPlayer((Player) source)
+                : new VelocityCommandSender(source),
+            invocation.arguments()
+        );
+    }
 
-        UniversalCommandSender commandSender;
-
-        if (source instanceof Player) {
-            commandSender = new VelocityPlayer((Player) source);
-        } else {
-            commandSender = new UniversalCommandSender() {
-
-                @Override
-                public boolean hasPermission(String permission) {
-                    return isEmpty(permission) || source.hasPermission(permission);
-                }
-
-                @Override
-                public void sendMessage(String message) {
-                    source.sendMessage(Component.text(message));
-                }
-
-                private boolean isEmpty(String string) {
-                    return string == null || string.isEmpty();
-                }
-            };
-        }
-
-        command.onCommand(commandSender, args);
+    @Override
+    public List<String> suggest(Invocation invocation) {
+        final CommandSource source = invocation.source();
+        return command.getSuggestions(
+            source instanceof Player
+                ? new VelocityPlayer((Player) source)
+                : new VelocityCommandSender(source),
+            invocation.arguments()
+        );
     }
 
     public static void register(Object plugin, UniversalCommand command) {

--- a/minecraft/src/main/java/org/spicord/velocity/server/VelocityCommandSender.java
+++ b/minecraft/src/main/java/org/spicord/velocity/server/VelocityCommandSender.java
@@ -1,0 +1,29 @@
+package org.spicord.velocity.server;
+
+import com.velocitypowered.api.command.CommandSource;
+import eu.mcdb.universal.command.UniversalCommandSender;
+import net.kyori.adventure.text.Component;
+
+public class VelocityCommandSender extends UniversalCommandSender {
+
+    private final CommandSource source;
+
+    public VelocityCommandSender(CommandSource source) {
+        this.source = source;
+    }
+
+    @Override
+    public boolean hasPermission(String permission) {
+        return isEmpty(permission) || source.hasPermission(permission);
+    }
+
+    @Override
+    public void sendMessage(String message) {
+        source.sendMessage(Component.text(message));
+    }
+
+    private boolean isEmpty(String string) {
+        return string == null || string.isEmpty();
+    }
+
+}


### PR DESCRIPTION
This PR adds command completion to the spicord command

When adding an addon to a bot, it suggests all registered addons that have not yet been added to the bot
When removing an addon from a bot, it suggests all addons that were added to the bot

The start command will only show disabled bots
The stop command will only show enabled bots

Example video:

https://github.com/user-attachments/assets/b1df7ec0-580c-4479-a5fa-4763f6d7d20c

The visibility of suggestions depends on whether the sender has the correct permissions:

https://github.com/user-attachments/assets/07400706-5851-492b-8e3d-98ed5fa16e41

I have tested these changes on a Paper, Spigot, Velocity, BungeeCord and Sponge server.

I moved each platform's CommandSender to their own class instead of creating it inside of the command execution method.

I changed Sponge's command from a parameterised command to a raw command as it allows manually adding suggestions.